### PR TITLE
Added option to smooth 2D contours

### DIFF
--- a/core/include/OptParser.h
+++ b/core/include/OptParser.h
@@ -103,6 +103,7 @@ class OptParser
 		float           scanrangeMax;
 		float           scanrangeyMin;
 		float           scanrangeyMax;
+    bool    smooth2d;
 		vector<TString> title;
 		bool            usage;
 		vector<TString> var;

--- a/core/src/GammaComboEngine.cpp
+++ b/core/src/GammaComboEngine.cpp
@@ -737,7 +737,7 @@ void GammaComboEngine::make1dPluginScan(MethodPluginScan *scannerPlugin, int cId
 ///
 /// Perform the 2D plugin scan. Runs toys in batch mode, and
 /// reads them back in.
-/// 
+///
 /// \param scannerPlugin - the scanner to run the scan with
 /// \param cId - the id of this combination on the command line
 ///
@@ -836,8 +836,10 @@ void GammaComboEngine::make1dPluginPlot(MethodPluginScan *sPlugin, MethodProbSca
 ///
 void GammaComboEngine::make2dPluginPlot(MethodPluginScan *sPlugin, MethodProbScan *sProb, int cId)
 {
-	sProb->plotOn(plot);
+	sProb->setTitle( sProb->getTitle() + " (Prob)");
+  sProb->plotOn(plot);
 	sProb->setLineColor(colorsLine[cId]);
+  sPlugin->setTitle( sPlugin->getTitle() + " (Plugin)");
 	sPlugin->plotOn(plot);
 	plot->Draw();
 }
@@ -1089,11 +1091,11 @@ void GammaComboEngine::scan()
 					MethodProbScan *scannerProb = new MethodProbScan(c);
 					if ( ! ( arg->isAction("plot") && arg->plotpluginonly ) ){
 						// we don't need the prob scanner if we just want to replot the plugin only
-						scannerProb->loadScanner(fb->getFileNameScanner(scannerProb));	
+						scannerProb->loadScanner(fb->getFileNameScanner(scannerProb));
 					}
 					MethodPluginScan *scannerPlugin = new MethodPluginScan(scannerProb);
 					if ( arg->isAction("plot") ){
-						scannerPlugin->loadScanner(fb->getFileNameScanner(scannerPlugin));	
+						scannerPlugin->loadScanner(fb->getFileNameScanner(scannerPlugin));
 					}
 					else {
 						if ( arg->coverageCorrectionID>0 ) {
@@ -1126,11 +1128,11 @@ void GammaComboEngine::scan()
 					MethodProbScan *scannerProb = new MethodProbScan(c);
 					if ( ! ( arg->isAction("plot") && arg->plotpluginonly ) ){
 						// we don't need the prob scanner if we just want to replot the plugin only
-						scannerProb->loadScanner(fb->getFileNameScanner(scannerProb));	
+						scannerProb->loadScanner(fb->getFileNameScanner(scannerProb));
 					}
 					MethodPluginScan *scannerPlugin = new MethodPluginScan(scannerProb);
 					if ( arg->isAction("plot") ){
-						scannerPlugin->loadScanner(fb->getFileNameScanner(scannerPlugin));	
+						scannerPlugin->loadScanner(fb->getFileNameScanner(scannerPlugin));
 					}
 					else {
 						make2dPluginScan(scannerPlugin, i);
@@ -1171,7 +1173,7 @@ void GammaComboEngine::printBanner()
 	cout << endl
 		<< "\033[1mGammaCombo v" << VTAG << " -- Developed by Till Moritz Karbach\033[0m " << endl
 		<< "                   Copyright (C) 2014, moritz.karbach@gmail.com" << endl
-		<< "                   All rights reserved under GPLv3, http://www.gnu.org/licenses/gpl.txt" << endl << endl ;	
+		<< "                   All rights reserved under GPLv3, http://www.gnu.org/licenses/gpl.txt" << endl << endl ;
 }
 
 ///

--- a/core/src/OneMinusClPlot2d.cpp
+++ b/core/src/OneMinusClPlot2d.cpp
@@ -41,7 +41,7 @@
 	linestyle[2].push_back(kSolid);
 	fillcolor[2].push_back(cb.lightcolor(fillcolor[1][0]));
 	fillstyle[2].push_back(1001);
-	// 4 sigma  
+	// 4 sigma
 	linecolor[3].push_back(cb.lightcolor(linecolor[2][0]));
 	linestyle[3].push_back(kSolid);
 	fillcolor[3].push_back(cb.lightcolor(fillcolor[2][0]));
@@ -50,7 +50,7 @@
 	linecolor[4].push_back(cb.lightcolor(linecolor[3][0]));
 	linestyle[4].push_back(kSolid);
 	fillcolor[4].push_back(cb.lightcolor(fillcolor[3][0]));
-	fillstyle[4].push_back(1001);  
+	fillstyle[4].push_back(1001);
 
 	// 2nd scanner
 	markerstyle.push_back(29);
@@ -154,27 +154,27 @@ void OneMinusClPlot2d::makeNewPlotStyle()
 	float thisMuchDarker = 0.8;
 
 	linecolor[0].push_back(cb.darklightcolor(linecolor[0][currentNumberOfStyles-1],thisMuchDarker));
-	linestyle[0].push_back(kSolid);                                                            
+	linestyle[0].push_back(kSolid);
 	fillcolor[0].push_back(cb.darklightcolor(fillcolor[0][currentNumberOfStyles-1],thisMuchDarker));
-	fillstyle[0].push_back(3013);                                                              
+	fillstyle[0].push_back(3013);
 
 	linecolor[1].push_back(cb.darklightcolor(linecolor[1][currentNumberOfStyles-1],thisMuchDarker));
-	linestyle[1].push_back(kSolid);                                                            
+	linestyle[1].push_back(kSolid);
 	fillcolor[1].push_back(cb.darklightcolor(fillcolor[1][currentNumberOfStyles-1],thisMuchDarker));
-	fillstyle[1].push_back(1001);                                                              
+	fillstyle[1].push_back(1001);
 
 	linecolor[2].push_back(cb.darklightcolor(linecolor[2][currentNumberOfStyles-1],thisMuchDarker));
-	linestyle[2].push_back(kSolid);                                                            
+	linestyle[2].push_back(kSolid);
 	fillcolor[2].push_back(cb.darklightcolor(fillcolor[2][currentNumberOfStyles-1],thisMuchDarker));
-	fillstyle[2].push_back(1001);                                                              
+	fillstyle[2].push_back(1001);
 
 	linecolor[3].push_back(cb.darklightcolor(linecolor[3][currentNumberOfStyles-1],thisMuchDarker));
-	linestyle[3].push_back(kSolid);                                                            
+	linestyle[3].push_back(kSolid);
 	fillcolor[3].push_back(cb.darklightcolor(fillcolor[3][currentNumberOfStyles-1],thisMuchDarker));
-	fillstyle[3].push_back(1001);                                                              
+	fillstyle[3].push_back(1001);
 
 	linecolor[4].push_back(cb.darklightcolor(linecolor[4][currentNumberOfStyles-1],thisMuchDarker));
-	linestyle[4].push_back(kSolid);                                                            
+	linestyle[4].push_back(kSolid);
 	fillcolor[4].push_back(cb.darklightcolor(fillcolor[4][currentNumberOfStyles-1],thisMuchDarker));
 	fillstyle[4].push_back(1001);
 }
@@ -423,10 +423,11 @@ TList* OneMinusClPlot2d::makeHoles(TList *contour)
 TMultiGraph* OneMinusClPlot2d::makeContours(int hCLid, int nContours, bool plotFilled, bool last)
 {
 	if ( arg->debug ) {
-		cout << "OneMinusClPlot2d::makeContours() : making contours of histogram id " << hCLid 
+		cout << "OneMinusClPlot2d::makeContours() : making contours of histogram id " << hCLid
 		<< ", type " << (histosType[hCLid]==kChi2?"kChi2":"kPvalue") << endl;
 	}
 	TH2F* h = histos[hCLid];
+  if ( arg->smooth2d ) h->Smooth();
 
 	// get coordinates of plotted area
 	float xmin = h->GetXaxis()->GetXmin();
@@ -440,7 +441,7 @@ TMultiGraph* OneMinusClPlot2d::makeContours(int hCLid, int nContours, bool plotF
 			h->GetNbinsX()+2,
 			h->GetXaxis()->GetXmin() - h->GetXaxis()->GetBinWidth(1),
 			h->GetXaxis()->GetXmax() + h->GetXaxis()->GetBinWidth(1),
-			h->GetNbinsY()+2,           
+			h->GetNbinsY()+2,
 			h->GetYaxis()->GetXmin() - h->GetYaxis()->GetBinWidth(1),
 			h->GetYaxis()->GetXmax() + h->GetYaxis()->GetBinWidth(1));
 	for ( int ix=1; ix<=hBoundaries->GetXaxis()->GetNbins(); ix++ ){
@@ -540,7 +541,7 @@ TMultiGraph* OneMinusClPlot2d::makeContours(int hCLid, int nContours, bool plotF
 	if ( arg->color.size()>hCLid ) styleId = arg->color[hCLid];
 	TMultiGraph *mg = new TMultiGraph(getUniqueRootName(), "graph");
 	for ( int ic=nContours-1; ic>=0; ic-- ){
-		drawContour(mg, contour[ic], 2, linecolor[ic][styleId], linestyle[ic][styleId], 
+		drawContour(mg, contour[ic], 2, linecolor[ic][styleId], linestyle[ic][styleId],
 				fillcolor[ic][styleId], fillstyle[ic][styleId], kDashed,
 				last, plotFilled);
 	}
@@ -642,7 +643,7 @@ void OneMinusClPlot2d::DrawFull()
 
 ///
 /// Draw the legend.
-/// 
+///
 void OneMinusClPlot2d::drawLegend()
 {
 	// set up the legend
@@ -726,7 +727,7 @@ void OneMinusClPlot2d::Draw()
 		cout << "OneMinusClPlot2d::makeNewPlotStyle() : WARNING : making a new plot style" << endl;
 		cout << "OneMinusClPlot2d::makeNewPlotStyle() :   for a new scanner that doesn't have" << endl;
 		cout << "OneMinusClPlot2d::makeNewPlotStyle() :   a style defined in the constructor." << endl;
-	}  
+	}
 	for ( int i=linecolor[0].size(); i<histos.size(); i++ ){
 		makeNewPlotStyle();
 	}
@@ -896,7 +897,7 @@ void OneMinusClPlot2d::drawSolutions()
 		for ( int iSol=0; iSol<scanners[i]->getNSolutions(); iSol++ )
 		{
 			/// if option 2 is given, only plot best fit points and equivalent ones
-			if ( arg->plotsolutions==2 
+			if ( arg->plotsolutions==2
 					&& iSol>0
 					&& scanners[i]->getSolution(iSol)->minNll() - scanners[i]->getSolution(0)->minNll() > 0.01 ) continue;
 			float xSol = scanners[i]->getScanVar1Solution(iSol);

--- a/core/src/OptParser.cpp
+++ b/core/src/OptParser.cpp
@@ -80,6 +80,7 @@ OptParser::OptParser()
 	scanrangeMin = -99;
 	scanrangeyMax = -99;
 	scanrangeyMin = -99;
+  smooth2d = false;
 	usage = false;
 	verbose = false;
 }
@@ -140,6 +141,7 @@ void OptParser::defineOptions()
 	availableOptions.push_back("scanforce");
 	availableOptions.push_back("scanrange");
 	availableOptions.push_back("scanrangey");
+  availableOptions.push_back("smooth2d");
 	availableOptions.push_back("title");
 	availableOptions.push_back("usage");
 	availableOptions.push_back("unoff");
@@ -382,6 +384,7 @@ void OptParser::parseArguments(int argc, char* argv[])
 	TCLAP::SwitchArg importanceArg("", "importance", "Enable importance sampling for plugin toys.", false);
 	TCLAP::SwitchArg nosystArg("", "nosyst", "Sets all systematic errors to zero.", false);
 	TCLAP::SwitchArg printcorArg("", "printcor", "Print the correlation matrix of each solution found.", false);
+  TCLAP::SwitchArg smooth2dArg("", "smooth2d", "Smooth 2D p-value or cl histograms for nicer contour (particularly useful for 2D plugin)", false);
 
 	// --------------- aruments that can be given multiple times
 	vector<string> vAction;
@@ -470,6 +473,7 @@ void OptParser::parseArguments(int argc, char* argv[])
 	if ( isIn<TString>(bookedOptions, "title" ) ) cmd.add( titleArg );
 	if ( isIn<TString>(bookedOptions, "sn2d" ) ) cmd.add(sn2dArg);
 	if ( isIn<TString>(bookedOptions, "sn" ) ) cmd.add(snArg);
+  if ( isIn<TString>(bookedOptions, "smooth2d" ) ) cmd.add( smooth2dArg );
 	if ( isIn<TString>(bookedOptions, "scanrangey" ) ) cmd.add( scanrangeyArg );
 	if ( isIn<TString>(bookedOptions, "scanrange" ) ) cmd.add( scanrangeArg );
 	if ( isIn<TString>(bookedOptions, "scanforce" ) ) cmd.add( scanforceArg );
@@ -569,6 +573,7 @@ void OptParser::parseArguments(int argc, char* argv[])
 	qh                = qhArg.getValue();
 	savenuisances1d   = snArg.getValue();
 	scanforce         = scanforceArg.getValue();
+  smooth2d          = smooth2dArg.getValue();
 	usage             = usageArg.getValue();
 	verbose           = verboseArg.getValue();
 
@@ -870,7 +875,7 @@ int OptParser::convertToIntWithCheck(TString parseMe, TString usage)
 		cout << usage << endl;
 		exit(1);
 	}
-	return parseMe.Atoi();	
+	return parseMe.Atoi();
 }
 
 ///
@@ -884,7 +889,7 @@ int OptParser::convertToDigitWithCheck(TString parseMe, TString usage)
 		cout << usage << endl;
 		exit(1);
 	}
-	return parseMe.Atoi();	
+	return parseMe.Atoi();
 }
 
 ///
@@ -897,7 +902,7 @@ int OptParser::convertToDigitWithCheck(TString parseMe, TString usage)
 ///
 /// \param parseMe		- the string provided to -c
 /// \param resultCmbId		- resulting combiner ID
-/// \param resultAddDelPdf	- vector of all PDF IDs, that are requested to be added or deleted 
+/// \param resultAddDelPdf	- vector of all PDF IDs, that are requested to be added or deleted
 /// 				 	to/from the combiner. If it is supposed to be added, a positive PDF ID
 ///					is stored, if it is supposed to be deleted, a negative PDF ID is stored
 ///
@@ -912,10 +917,10 @@ void OptParser::parseCombinerString(TString parseMe, int& resultCmbId, vector<in
 	usage += "  -c 26:+12\n";
 	usage += "  -c 26:+12,-3\n";
 	// simplest case, no modification
-	if ( !parseMe.Contains(":") ){ 
+	if ( !parseMe.Contains(":") ){
 		resultCmbId = convertToDigitWithCheck(parseMe, usage);
 		return;
-	}	
+	}
 	// advanced case, there are PDF modifications
 	// 1. parse leading combiner ID
 	TObjArray *array = parseMe.Tokenize(":"); // split string at ":"


### PR DESCRIPTION
Added a new option (--smooth2d) which will simply smooth the 2D
likelihood or pvalue histogram to give a nicer looking contour
(particularly useful for 2D plugin method plots).

See comparison plots attached

Many of the line changes are for indenting (please ignore those)

*No smoothing*
![2d](https://cloud.githubusercontent.com/assets/1140576/5667450/03905ffe-9768-11e4-9db8-f480391b681c.png)
*With smoothing*
![2d_smooth](https://cloud.githubusercontent.com/assets/1140576/5667503/a2c9d1a4-9768-11e4-98b2-039c6ee13b69.png)
